### PR TITLE
Allow per-channel extraction

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ var Meyda = {
   },
 
   createMeydaAnalyzer: function (options) {
-    return new MeydaAnalyzer(options, Meyda);
+    return new MeydaAnalyzer(options, Object.assign({}, Meyda));
   },
 
   extract: function (feature, signal, previousSignal) {

--- a/src/meyda-wa.js
+++ b/src/meyda-wa.js
@@ -97,7 +97,9 @@ export class MeydaAnalyzer {
   }
 
   setSource(source) {
-    source.connect(this._m.spn);
+    this._m.source && this._m.source.disconnect(this._m.spn);
+    this._m.source = source;
+    this._m.source.connect(this._m.spn);
   }
 
   get(features) {

--- a/src/meyda-wa.js
+++ b/src/meyda-wa.js
@@ -107,6 +107,10 @@ export class MeydaAnalyzer {
     this._m.source.connect(this._m.spn);
   }
 
+  setChannel(channel) {
+    this._m.channel = channel;
+  }
+
   get(features) {
     if (this._m.inputData) {
       return this._m.extract(

--- a/src/meyda-wa.js
+++ b/src/meyda-wa.js
@@ -26,10 +26,15 @@ export class MeydaAnalyzer {
     this._m.windowingFunction = options.windowingFunction || 'hanning';
     this._m.featureExtractors = featureExtractors;
     this._m.EXTRACTION_STARTED = options.startImmediately || false;
+    this._m.channel = typeof options.channel === 'number' ? options.channel : 0;
+    this._m.inputs = options.inputs || 1;
+    this._m.outputs = options.outputs || 1;
 
     //create nodes
     this._m.spn = this._m.audioContext.createScriptProcessor(
-      this._m.bufferSize, 1, 1);
+      this._m.bufferSize,
+      this._m.inputs,
+      this._m.outputs);
     this._m.spn.connect(this._m.audioContext.destination);
 
     this._m._featuresToExtract = options.featureExtractors || [];
@@ -57,7 +62,7 @@ export class MeydaAnalyzer {
         this._m.previousInputData = this._m.inputData;
       }
 
-      this._m.inputData = e.inputBuffer.getChannelData(0);
+      this._m.inputData = e.inputBuffer.getChannelData(this._m.channel);
 
       if (!this._m.previousInputData) {
         var buffer = this._m.inputData;


### PR DESCRIPTION
Hello everyone !

I've done some very little work to add the ability to :

* disconnect previous source when setting a new one
* allow creation of multiple Meyda instances
* provide options to the MeydaAnalyzer to extract specific channel data

I've been working with [this gist](https://gist.github.com/hugohil/027cce877c5dd5a534324e2abdca861f), so you can just download the file and set the correct path to your local meyda installation. You can find the audio samples [here (Google Drive link)](https://drive.google.com/open?id=1guk_55XpHK4e3euGJ1hCL-lNqHbCG2tx), they are public domain (found [here](https://freepd.com/)). The `stereo.mp3` file is simply a sample with paning effect such as :

![screenshot from 2018-01-08 15-31-27](https://user-images.githubusercontent.com/4352715/34675176-0a05ee9a-f489-11e7-9bb0-4b027051f457.png)

Cheers ! :)

P.S : This PR is a reboot of #213 based on the current master branch (`4.1.3`). Sorry for polluting  the repository with redundant PRs but it was way simpler for me to just start over from current master.
P.P.S : since last assignees were @jakubfiala @2xAA and @nevosegal, allow me to poke you :)
  
  