### PR TITLE
Fix bug in ZCR

### DIFF
--- a/src/extractors/zcr.js
+++ b/src/extractors/zcr.js
@@ -4,9 +4,9 @@ export default function() {
   }
 
   var zcr = 0;
-  for (var i = 0; i < arguments[0].signal.length; i++) {
-    if ((arguments[0].signal[i] >= 0 && arguments[0].signal[i + 1] < 0) ||
-         (arguments[0].signal[i] < 0 && arguments[0].signal[i + 1] >= 0)) {
+  for (var i = 1; i < arguments[0].signal.length; i++) {
+    if ((arguments[0].signal[i-1] >= 0 && arguments[0].signal[i] < 0) ||
+         (arguments[0].signal[i-1] < 0 && arguments[0].signal[i] >= 0)) {
       zcr++;
     }
   }


### PR DESCRIPTION
ZCR was in some cases missing one zero crossing per buffer by overrunning the buffer on the final iteration. This commit removes the buffer overrun case.