### PR TITLE
fix typo in offline-cli guide

### DIFF
--- a/docs/guides/offline-cli.md
+++ b/docs/guides/offline-cli.md
@@ -27,7 +27,7 @@ To call Meyda's command line interface, we first need to install the Meyda
 package globally, using npm.
 
 ```sh
-$ npm instal --global meyda
+$ npm install --global meyda
 ```
 
 Once that command has run, the Meyda executable should be available on your


### PR DESCRIPTION
The correct npm command is `npm install`