### PR TITLE
chore(dct): bumps dct version from 0.0.3 to 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2697,9 +2697,9 @@
       "dev": true
     },
     "dct": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/dct/-/dct-0.0.3.tgz",
-      "integrity": "sha1-GTkKg0OIodOhNz+e3+UGIgdISdM="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dct/-/dct-0.1.0.tgz",
+      "integrity": "sha512-/uUtEniuMq1aUxvLAoDtAduyl12oM1zhA/le2f83UFN/9+4KDHXFB6znEfoj5SDDLiTpUTr26NpxC7t8IFOYhQ=="
     },
     "debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "webpack-stream": "^5.2.1"
   },
   "dependencies": {
-    "dct": "0.0.3",
+    "dct": "0.1.0",
     "fftjs": "0.0.4",
     "node-getopt": "^0.2.3",
     "wav": "^1.0.0"


### PR DESCRIPTION
Fixes cosMap declaration error in the dct module when in strict mode.
We fixed this on dct's side but never updated Meyda with the new package 🤷‍♂ 