### PR TITLE
Allow setting number of mfcc coefficients in Analyzer constructor

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ import {MeydaAnalyzer} from './meyda-wa';
  * @property {string} [windowingFunction] - The Windowing Function to apply to the signal before transformation to the frequency domain
  * @property {string|Array.<string>} [featureExtractors] - Specify the feature extractors you want to run on the audio.
  * @property {boolean} [startImmediately] - Pass `true` to start feature extraction immediately
+ * @property {number} [numberOfMFCCCoefficients] - The number of MFCC co-efficients that the MFCC feature extractor should return
  */
 
  /**
@@ -121,6 +122,11 @@ var Meyda = {
    */
   featureExtractors: extractors,
   EXTRACTION_STARTED: false,
+  /**
+   * The number of MFCC co-efficients that the MFCC feature extractor should return
+   * @instance
+   * @member {number}
+   */
   numberOfMFCCCoefficients: 13,
   _featuresToExtract: [],
   windowing: utilities.applyWindow,

--- a/src/meyda-wa.js
+++ b/src/meyda-wa.js
@@ -19,6 +19,7 @@ import * as featureExtractors from './featureExtractors';
   *   "bufferSize": 512,
   *   "featureExtractors": ["rms"],
   *   "inputs": 2,
+  *   "numberOfMFCCCoefficients": 20
   *   "callback": features => {
   *     levelRangeElement.value = features.rms;
   *   }
@@ -53,6 +54,7 @@ export class MeydaAnalyzer {
     this._m.channel = typeof options.channel === 'number' ? options.channel : 0;
     this._m.inputs = options.inputs || 1;
     this._m.outputs = options.outputs || 1;
+    this._m.numberOfMFCCCoefficients = options.numberOfMFCCCoefficients || this._m.numberOfMFCCCoefficients || 13;
 
     //create nodes
     this._m.spn = this._m.audioContext.createScriptProcessor(
@@ -69,7 +71,7 @@ export class MeydaAnalyzer {
       this._m.sampleRate,
       this._m.bufferSize);
     this._m.melFilterBank = utilities.createMelFilterBank(
-      this._m.melBands,
+      Math.max(this._m.melBands, this._m.numberOfMFCCCoefficients),
       this._m.sampleRate,
       this._m.bufferSize);
 


### PR DESCRIPTION
## Summary

As stated on the tin: allowing users to set the number of MFCCs the analyzer returns.
Prior to this change, it would default to 13. However, this limitation is not ideal, as many applications require a different amount of coefficients.

To return N coefficients, we need at least N mel bands (although usually we want to have more bands, as we discard the higher ones - perhaps a TODO for later).
With this change I'm also making sure users don't need to set `melBands` if they specify a number of coefficients which is higher than the default number of mel bands (`26`).

## Test plan

Run `npm test`: `97 passing (140ms)`

Run `npm build` and use the code just built in a dummy project:

```
    const analyzer = Meyda.createMeydaAnalyzer({
      audioContext: audioCtx,
      source: audioSrc,
      bufferSize: 512,
      // I can now specify the number of coefficients (up to 40)
      numberOfMFCCCoefficients: 40,
      // I don't need to set melBands.
      featureExtractors: ["mfcc"],
      callback: ({ mfcc }: { mfcc: number[] }) => {
          console.log(mfcc);
      }
    })
```

The commit that was reverted (https://github.com/meyda/meyda/commit/9605e5ed073895484652bfc27c5a1507eb74d1a8) didn't take into account the `melBands` so the above code would throw an error (because 40 MFCCs is higher than the default 26 mel bands)<br>
![ss_1](https://user-images.githubusercontent.com/33761650/71526072-e04fff80-28cc-11ea-9226-4f2f53aaad3b.jpg)


With this change, the above code does what it's supposed to.<br>
![ss_2](https://user-images.githubusercontent.com/33761650/71526074-e5ad4a00-28cc-11ea-817a-a643b2a7c828.jpg)

