### PR TITLE
fix(package exports): revert prettier rewrite

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,0 +1,26 @@
+var meyda = require("../dist/node");
+
+const EXPECTED_EXPORTS = [
+  "audioContext",
+  "spn",
+  "bufferSize",
+  "sampleRate",
+  "melBands",
+  "chromaBands",
+  "callback",
+  "windowingFunction",
+  "featureExtractors",
+  "EXTRACTION_STARTED",
+  "numberOfMFCCCoefficients",
+  "_featuresToExtract",
+  "windowing",
+  "_errors",
+  "createMeydaAnalyzer",
+  "extract",
+];
+
+describe("main", () => {
+  test("meyda exports at least currently expected fields", () => {
+    expect(Object.keys(meyda)).toEqual(EXPECTED_EXPORTS);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,1 @@
-import main from "./main";
-export default main;
+module.exports = require("./main");


### PR DESCRIPTION
The prettier rewrite in #823 decided to export an es6 module rather than our default. I didn't
expect prettier to change behaviour, and I didn't catch it. This means that meyda@5.1.4 and
meyda@5.1.5 are bad, and will need to be deprecated. This commit introduces a test that will catch
this issue in the future.