### PR TITLE
fix(mfcc): adjust mfcc constant

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -93,13 +93,15 @@ export function mean(a) {
   );
 }
 
+const MEL_CONSTANT = 1127;
+
 function _melToFreq(melValue) {
-  var freqValue = 700 * (Math.exp(melValue / 1125) - 1);
+  var freqValue = 700 * (Math.exp(melValue / MEL_CONSTANT) - 1);
   return freqValue;
 }
 
 function _freqToMel(freqValue) {
-  var melValue = 1125 * Math.log(1 + freqValue / 700);
+  var melValue = MEL_CONSTANT * Math.log(1 + freqValue / 700);
   return melValue;
 }
 


### PR DESCRIPTION
A constant exists in the formula for converting between hz and the mel scale, which Meyda has had
set to 1125. The mel-scale is not standardised, but it seems that the most popular formula comes
from "Speech communication: human and machine" by Douglas O'Shaughnessy. That formula has the
constant as 1127. The issue mentioned below was opened, and suggests that we converge on
O'Shaughnessy's constant. This commit implements that change.

BREAKING CHANGE: A change in how Meyda performs frequency to mel scale conversion will result in
different mel-values between this and previous versions of Meyda.

fix #458