### PR TITLE
Switch from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: build
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 13.x, 14.x, 15.x, 16.x]
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run test
+        run: npm run test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,5 +19,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Run install
+        run: npm install --ci
+
       - name: Run test
         run: npm run test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: build
+name: lint
 on: [pull_request]
 
 jobs:
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x, 14.x, 15.x, 16.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v1
@@ -22,8 +22,5 @@ jobs:
       - name: Run install
         run: npm install --ci
 
-      - name: Run build
-        run: npm run build
-
-      - name: Run test
-        run: npm run test
+      - name: Run lint
+        run: npm run lint

--- a/.github/workflows/merge-build.yml
+++ b/.github/workflows/merge-build.yml
@@ -1,0 +1,39 @@
+name: merge-build
+on:
+  [pull_request]
+  # We should run this only on master, but we've got to dry run test it on a PR
+  # push:
+  #   branches:
+  #     - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run install
+        run: npm install --ci
+
+      - name: Run build
+        run: npm run build
+
+      - name: Run test
+        run: npm run test
+
+      - name: Semantic Release
+        # run: npm run semantic-release
+        # Do a dry run for now so that we can see if it works!
+        run: ./node_modules/.bin/semantic-release --dry-run

--- a/.github/workflows/merge-build.yml
+++ b/.github/workflows/merge-build.yml
@@ -1,10 +1,8 @@
 name: merge-build
 on:
-  [pull_request]
-  # We should run this only on master, but we've got to dry run test it on a PR
-  # push:
-  #   branches:
-  #     - master
+  push:
+    branches:
+      - master
 
 jobs:
   build:
@@ -34,6 +32,4 @@ jobs:
         run: npm run test
 
       - name: Semantic Release
-        # run: npm run semantic-release
-        # Do a dry run for now so that we can see if it works!
-        run: ./node_modules/.bin/semantic-release --dry-run
+        run: ./node_modules/.bin/semantic-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,9 @@
 language: node_js
 node_js:
-- '10'
-- '12'
-- '13'
-- '14'
-- '15'
-- '16'
+  - "16"
 # https://travis-ci.community/t/npm-ci-will-fail-if-cached-dependency-includes-npm/4203
 cache:
   npm: false
 sudo: false
 script:
-  - commitlint-travis
-  - npm run test
-  - npm run lint
-  - npm run semantic-release
-notifications:
-  slack:
-    secure: Z+kV8Q/rDT7AubCvmB8sQGcoBYpM3pRTALhYoi0eZKYtSsqzn0EPdOT7B0zG+UZ7smooDRjdSy+ba1KCbOCKfq4Q/Rov3v3qQdoASmseLRpniz/Lr2sJZtq5h3NXT0MTId+E1TzZZh2eokzXc7inP4ZOxEkoXPTclDqQA6A8JUA=
+  - echo "hooray :)"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "meyda": "./bin/cli.js"
   },
   "scripts": {
-    "pretest": "npm run lint && npm run build",
     "test": "jest",
     "build": "NODE_ENV=production; rollup -c rollup.config.js",
     "default": "npm test && npm run lint",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@babel/preset-env": "^7.7.7",
     "@commitlint/cli": "^12.0.1",
     "@commitlint/config-conventional": "^12.0.1",
-    "@commitlint/travis-cli": "^12.0.1",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
@@ -56,7 +55,6 @@
     "glob": "^7.1.7",
     "husky": "^6.0.0",
     "jest": "^27.0.1",
-    "jest-github-reporter": "^1.0.0",
     "jsdoc": "^3.6.3",
     "rollup": "^2.49.0",
     "rollup-plugin-node-polyfills": "^0.2.1",
@@ -78,8 +76,7 @@
   },
   "jest": {
     "reporters": [
-      "default",
-      "jest-github-reporter"
+      "default"
     ],
     "testPathIgnorePatterns": [
       "__tests__/TestData.js"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "scripts": {
     "test": "jest",
     "build": "NODE_ENV=production; rollup -c rollup.config.js",
-    "default": "npm test && npm run lint",
-    "lint": "eslint src __tests__",
+    "lint": "eslint -f compact src __tests__",
     "generatereferencedocs": "jsdoc src/meyda-wa.js src/main.js -d docs/reference -R docs/README.md",
     "semantic-release": "semantic-release"
   },


### PR DESCRIPTION
fix #840

This PR will contain all the commits for the migration from Travis.

TODO:
- [x] Pull eslint out of matrix build and just run once
- [x] Add post merge action - build, test, semantic-release
- [ ] Bonus: report the following as properly annotated checks/comments:
	- [ ] What semantic release would release if the PR were merged
	- [x] eslint violations
	- [ ] prettier violations*
	- [ ] jest failures
- [x] Make semantic-release create a release on GitHub
- [x] Make sure semantic-release has a token to talk to NPM
- [ ] Switch post-merge check to run post merge, remove dry-run from semantic-release

* We don't actually have Prettier in Meyda.