### PR TITLE
Spectral Flux is weird and needs a little bit of love probably

### DIFF
--- a/__tests__/extractors/positiveFlux.ts
+++ b/__tests__/extractors/positiveFlux.ts
@@ -2,13 +2,13 @@ import TestData from "../TestData";
 import { fft } from "fftjs";
 
 // Setup
-var spectralFlux = require("../../dist/node/extractors/spectralFlux");
+var positiveFlux = require("../../dist/node/extractors/positiveFlux");
 
 var COMPLEX_SPECTRUM = fft(TestData.VALID_SIGNAL);
 
-describe("spectralFlux", () => {
-  test("should return correct Spectral Flux value", (done) => {
-    var en = spectralFlux({
+describe("positiveFlux", () => {
+  test("should return correct Positive Flux value", (done) => {
+    var en = positiveFlux({
       complexSpectrum: COMPLEX_SPECTRUM,
       previousComplexSpectrum: {
         real: COMPLEX_SPECTRUM.real.map((e) => e * 0.8),
@@ -16,14 +16,14 @@ describe("spectralFlux", () => {
       bufferSize: TestData.VALID_SIGNAL.length,
     });
 
-    expect(en).toEqual(1.03425562865083e-7);
+    expect(en).toEqual(2.1288412531209104e-8);
 
     done();
   });
 
   test.skip("should throw an error when passed an empty object", (done) => {
     try {
-      var en = spectralFlux({});
+      var en = positiveFlux({});
     } catch (e) {
       done();
     }
@@ -31,7 +31,7 @@ describe("spectralFlux", () => {
 
   test.skip("should throw an error when not passed anything", (done) => {
     try {
-      var en = spectralFlux();
+      var en = positiveFlux();
     } catch (e) {
       done();
     }
@@ -39,7 +39,7 @@ describe("spectralFlux", () => {
 
   test.skip("should throw an error when passed something invalid", (done) => {
     try {
-      var en = spectralFlux({ signal: "not a signal" });
+      var en = positiveFlux({ signal: "not a signal" });
     } catch (e) {
       done();
     }

--- a/__tests__/extractors/spectralFlux.ts
+++ b/__tests__/extractors/spectralFlux.ts
@@ -1,0 +1,47 @@
+import TestData from "../TestData";
+import { fft } from "fftjs";
+
+// Setup
+var spectralFlux = require("../../dist/node/extractors/spectralFlux");
+
+var COMPLEX_SPECTRUM = fft(TestData.VALID_SIGNAL);
+
+describe("spectralFlux", () => {
+  test("should return correct Spectral Flux value", (done) => {
+    var en = spectralFlux({
+      complexSpectrum: COMPLEX_SPECTRUM,
+      previousComplexSpectrum: {
+        real: COMPLEX_SPECTRUM.real.map((e) => e * 0.8),
+      },
+      bufferSize: TestData.VALID_SIGNAL.length,
+    });
+
+    expect(en).toEqual(5.3495817947386035);
+
+    done();
+  });
+
+  test("should throw an error when passed an empty object", (done) => {
+    try {
+      var en = spectralFlux({});
+    } catch (e) {
+      done();
+    }
+  });
+
+  test("should throw an error when not passed anything", (done) => {
+    try {
+      var en = spectralFlux();
+    } catch (e) {
+      done();
+    }
+  });
+
+  test("should throw an error when passed something invalid", (done) => {
+    try {
+      var en = spectralFlux({ signal: "not a signal" });
+    } catch (e) {
+      done();
+    }
+  });
+});

--- a/docs/audio-features.md
+++ b/docs/audio-features.md
@@ -81,8 +81,8 @@ To use RMS in applications where you expect a ceiling on each audio feature, we 
 `spectralFlux`
 
 - _Description_: A measure of how quickly the spectrum of a signal is changing. It is calculated by computing the difference between the current spectrum and that of the previous frame.
-- _What Is It Used For_: Often corresponds to perceptual "roughness" of a sound. Can be used for example, to determine the timbre of a sound.
-- _Range_: Starts at `0.0`. This has no upper range as it depends on the input signal.
+- _What Is It Used For_: Often corresponds to perceptual "roughness" of a sound. Can be used for example, to determine the timbre of a sound, and onset detection.
+- _Range_: Starts at `0.0`. The upper bound is equal to the square root of the buffer size.
 
 ### Spectral Slope
 

--- a/src/extractors/positiveFlux.ts
+++ b/src/extractors/positiveFlux.ts
@@ -7,14 +7,16 @@ export default function ({
   complexSpectrum: { real: number[]; imag: number[] };
   previousComplexSpectrum: { real: number[]; imag: number[] };
 }): number {
-  if (!Array.isArray(complexSpectrum.real)) {
-    throw new TypeError();
-  }
-
   if (!previousComplexSpectrum) {
     return 0;
   }
 
+  if (
+    typeof complexSpectrum.real !== "object" ||
+    typeof complexSpectrum.imag != "object"
+  ) {
+    throw new TypeError();
+  }
   const normalizedRealComponent = normalizeToOne(complexSpectrum.real);
   const previousNormalizedRealComponent = normalizeToOne(
     previousComplexSpectrum.real
@@ -23,9 +25,9 @@ export default function ({
   let sf = 0;
   for (let i = 0; i < normalizedRealComponent.length; i++) {
     let x =
-      Math.abs(normalizedRealComponent[i]) -
-      Math.abs(previousNormalizedRealComponent[i]);
-    sf += Math.pow(x, 2);
+      Math.abs(previousNormalizedRealComponent[i]) -
+      Math.abs(normalizedRealComponent[i]);
+    sf += Math.pow(Math.max(x, 0), 2);
   }
 
   return Math.sqrt(sf);

--- a/src/extractors/positiveFlux.ts
+++ b/src/extractors/positiveFlux.ts
@@ -11,12 +11,6 @@ export default function ({
     return 0;
   }
 
-  if (
-    typeof complexSpectrum.real !== "object" ||
-    typeof complexSpectrum.imag != "object"
-  ) {
-    throw new TypeError();
-  }
   const normalizedRealComponent = normalizeToOne(complexSpectrum.real);
   const previousNormalizedRealComponent = normalizeToOne(
     previousComplexSpectrum.real

--- a/src/extractors/spectralFlux.ts
+++ b/src/extractors/spectralFlux.ts
@@ -1,24 +1,21 @@
-// This file isn't being typechecked at all because there are major issues with it.
-// See #852 for details. Once that's merged, this file should be typechecked.
-// @ts-nocheck
 export default function ({
-  signal,
-  previousSignal,
-  bufferSize,
+  complexSpectrum,
+  previousComplexSpectrum
 }: {
-  signal: Float32Array;
-  previousSignal: Float32Array;
-  bufferSize: number;
+  complexSpectrum: {real: number[]; imag: number[]};
+  previousComplexSpectrum: {real: number[]; imag: number[]};
 }): number {
-  if (typeof signal !== "object" || typeof previousSignal != "object") {
+  if (typeof complexSpectrum.real !== "object" || typeof complexSpectrum.imag != "object") {
     throw new TypeError();
   }
 
   let sf = 0;
-  for (let i = -(bufferSize / 2); i < signal.length / 2 - 1; i++) {
-    x = Math.abs(signal[i]) - Math.abs(previousSignal[i]);
-    sf += (x + Math.abs(x)) / 2;
+  for (let i = 0; i < complexSpectrum.real.length; i++) {
+    let x =
+      Math.abs(complexSpectrum.real[i]) -
+      Math.abs(previousComplexSpectrum.real[i]);
+    sf += Math.pow(x, 2);
   }
 
-  return sf;
+  return Math.sqrt(sf);
 }

--- a/src/extractors/spectralFlux.ts
+++ b/src/extractors/spectralFlux.ts
@@ -1,19 +1,32 @@
+import { normalizeToOne } from "../utilities";
+
 export default function ({
   complexSpectrum,
-  previousComplexSpectrum
+  previousComplexSpectrum,
 }: {
-  complexSpectrum: {real: number[]; imag: number[]};
-  previousComplexSpectrum: {real: number[]; imag: number[]};
+  complexSpectrum: { real: number[]; imag: number[] };
+  previousComplexSpectrum: { real: number[]; imag: number[] };
 }): number {
-  if (typeof complexSpectrum.real !== "object" || typeof complexSpectrum.imag != "object") {
-    throw new TypeError();
+  if (!previousComplexSpectrum) {
+    return 0;
   }
 
+  if (
+    typeof complexSpectrum.real !== "object" ||
+    typeof complexSpectrum.imag != "object"
+  ) {
+    throw new TypeError();
+  }
+  const normalizedRealComponent = normalizeToOne(complexSpectrum.real);
+  const previousNormalizedRealComponent = normalizeToOne(
+    previousComplexSpectrum.real
+  );
+
   let sf = 0;
-  for (let i = 0; i < complexSpectrum.real.length; i++) {
+  for (let i = 0; i < normalizedRealComponent.length; i++) {
     let x =
-      Math.abs(complexSpectrum.real[i]) -
-      Math.abs(previousComplexSpectrum.real[i]);
+      Math.abs(normalizedRealComponent[i]) -
+      Math.abs(previousNormalizedRealComponent[i]);
     sf += Math.pow(x, 2);
   }
 

--- a/src/extractors/spectralFlux.ts
+++ b/src/extractors/spectralFlux.ts
@@ -7,10 +7,6 @@ export default function ({
   complexSpectrum: { real: number[]; imag: number[] };
   previousComplexSpectrum: { real: number[]; imag: number[] };
 }): number {
-  if (!Array.isArray(complexSpectrum.real)) {
-    throw new TypeError();
-  }
-
   if (!previousComplexSpectrum) {
     return 0;
   }

--- a/src/featureExtractors.ts
+++ b/src/featureExtractors.ts
@@ -15,6 +15,7 @@ import mfcc from "./extractors/mfcc";
 import chroma from "./extractors/chroma";
 import powerSpectrum from "./extractors/powerSpectrum";
 import spectralFlux from "./extractors/spectralFlux";
+import positiveFlux from "./extractors/positiveFlux";
 
 let buffer = function (args) {
   return args.signal;
@@ -49,4 +50,5 @@ export {
   mfcc,
   chroma,
   spectralFlux,
+  positiveFlux,
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,12 +29,14 @@ export interface MeydaFeaturesObject {
   rms: number;
   spectralCentroid: number;
   spectralFlatness: number;
+  spectralFlux: number;
   spectralKurtosis: number;
   spectralRolloff: number;
   spectralSkewness: number;
   spectralSlope: number;
   spectralSpread: number;
   zcr: number;
+  positiveFlux: number;
 }
 
 export type MeydaWindowingFunction =
@@ -63,7 +65,8 @@ export type MeydaAudioFeature =
   | "spectralSlope"
   | "spectralSpread"
   | "zcr"
-  | "buffer";
+  | "buffer"
+  | "positiveFlux";
 
 /**
  * A type representing an audio signal. In general it should be an array of


### PR DESCRIPTION
Spectral flux has an implementation error - it was referring to a null object. I fixed that, but then realized that spectral flux is doing the euclidean distance between two _signals_, not two spectra, which seems to be incorrect from my reading. We'll need to review and fix this. I think because it's changing what the original behavior was if we were to switch to spectra, this should be considered a breaking change.

fix #236 