### PR TITLE
Fix issue with cli wrongly processing wav

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -136,18 +136,6 @@
     function (chunk) {
       //convert to normal array so we can concatenate
       var _chunk = typedToArray(chunk);
-      //check if chunk is bigger than frame
-      if (_chunk.length > FRAME_SIZE) {
-        // if so, we'll extract stuff from it frame by frame, until we're left with something that's short enough to buffer
-        while (_chunk.length > FRAME_SIZE) {
-          var frame = _chunk.slice(0, FRAME_SIZE);
-          _chunk.splice(0, HOP_SIZE);
-          extractFeatures(frame);
-          if (!opt.options.p) process.stdout.write("-");
-          frameCount++;
-        }
-      }
-
       buffer = buffer.concat(_chunk);
       //if we're long enough, splice the frame, and extract features on it
       while (buffer.length >= FRAME_SIZE) {


### PR DESCRIPTION
There was an issue with the wav file being processed wrongly. It first processed the new chunk before it concated it to the previous buffer. If there is still something in the buffer, it will get processed after the the chunk, therefore changing the order of the data. It should be processed in the order it got in. Not sure if my explanation is clear, please let me know if its confusing and I'll try to improve it