### PR TITLE
chore(semantic-release): disable for docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,6 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
     commit-message:
-      prefix: fix
-      prefix-development: chore
+      prefix: docs
+      prefix-development: docs
       include: scope


### PR DESCRIPTION
I just triggered a release of meyda because dependabot updated a non-dev dependency of the docs package. That isn't ideal. From now on, all updates of all deps in docs will be tagged with "docs"