### PR TITLE
feat: add numberOfBarkBands for loudness feature

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "useTabs": false,
+  "tabWidth": 2,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "trailingComma": "es5"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "meyda",
       "version": "0.0.0-development",
       "license": "MIT",
       "workspaces": [
@@ -11701,6 +11702,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"

--- a/src/extractors/loudness.ts
+++ b/src/extractors/loudness.ts
@@ -1,9 +1,11 @@
 export default function ({
   ampSpectrum,
   barkScale,
+  numberOfBarkBands = 24,
 }: {
   ampSpectrum: Float32Array;
   barkScale: Float32Array;
+  numberOfBarkBands?: number;
 }): {
   specific: Float32Array;
   total: number;
@@ -12,7 +14,7 @@ export default function ({
     throw new TypeError();
   }
 
-  var NUM_BARK_BANDS = 24;
+  var NUM_BARK_BANDS = numberOfBarkBands;
   var specific = new Float32Array(NUM_BARK_BANDS);
   var total = 0;
   var normalisedSpectrum = ampSpectrum;

--- a/src/main.ts
+++ b/src/main.ts
@@ -131,6 +131,12 @@ var Meyda = {
    * @member {number}
    */
   numberOfMFCCCoefficients: 13,
+  /**
+   * The number of bark bands that the loudness feature extractor should return
+   * @instance
+   * @member {number}
+   */
+  numberOfBarkBands: 24,
   _featuresToExtract: [],
   windowing: utilities.applyWindow,
   _errors: {
@@ -285,6 +291,7 @@ var Meyda = {
         previousAmpSpectrum: this.previousAmpSpectrum,
         previousComplexSpectrum: this.previousComplexSpectrum,
         numberOfMFCCCoefficients: this.numberOfMFCCCoefficients,
+        numberOfBarkBands: this.numberOfBarkBands,
       });
     };
 

--- a/src/meyda-wa.ts
+++ b/src/meyda-wa.ts
@@ -59,6 +59,8 @@ export class MeydaAnalyzer {
       options.numberOfMFCCCoefficients ||
       this._m.numberOfMFCCCoefficients ||
       13;
+    this._m.numberOfBarkBands =
+      options.numberOfBarkBands || this._m.numberOfBarkBands || 24;
 
     //create nodes
     this._m.spn = this._m.audioContext.createScriptProcessor(


### PR DESCRIPTION
This PR makes `numberOfBarkBands` for the `loudness` feature customizable instead of being hard-coded to `24`.

I followed the example set by `numberOfMFCCCoefficients`.

I also had to add a `.prettierrc` so my vscode wouldn't apply global prettier settings. I believe it's a best practice to always include these settings locally per-repo so no matter who's editing the project, they'll all have consistent styling.

Cheers 💪 😃 