### PR TITLE
fix(modules): expose esmodule

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "Real-time feature extraction for the web audio api",
   "main": "./dist/node/main.js",
   "browser": "./dist/web/meyda.min.js",
-  "jsnext:main": "./src/main.js",
+  "jsnext:main": "./dist/esm/main.js",
+  "types": "./dist/esm/main.d.ts",
   "bin": {
     "meyda": "./bin/cli.js"
   },
   "scripts": {
     "test": "jest",
-    "build": "NODE_ENV=production; rollup -c rollup.config.js",
+    "build": "NODE_ENV=production; tsc && rollup -c rollup.config.js",
     "lint": "tsc --noEmit && eslint -f compact --ext .js,.jsx,.ts,.tsx src __tests__ docs/src bin",
     "generatereferencedocs": "typedoc src/meyda-wa.ts src/main.ts --out docs/reference --readme docs/README.md",
     "semantic-release": "semantic-release",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "exclude": ["dist"],
+  "exclude": ["./dist", "./docs", "./__tests__", "./rollup.config.js", "./bin"],
   "compilerOptions": {
-    "outDir": "./typescript-built",
+    "outDir": "./dist/esm",
+    "declaration": true,
     "allowJs": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -14,7 +15,9 @@
     "strictFunctionTypes": true,
     "strictPropertyInitialization": true,
     "noImplicitAny": false,
-    "noImplicitThis": false
+    "noImplicitThis": false,
+    "rootDir": "./src",
+    "module": "esnext"
   },
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Recommended"


### PR DESCRIPTION
src used to be in esmodules and was exposed, but now that we're in typescript, we have to build them.

fixes: #1052