### PR TITLE
fix(spectralflux): use magnitude spectrum rather than real component of complex spectrum

### DIFF
--- a/__tests__/extractors/positiveFlux.ts
+++ b/__tests__/extractors/positiveFlux.ts
@@ -12,11 +12,12 @@ describe("positiveFlux", () => {
       complexSpectrum: COMPLEX_SPECTRUM,
       previousComplexSpectrum: {
         real: COMPLEX_SPECTRUM.real.map((e) => e * 0.8),
+        imag: COMPLEX_SPECTRUM.real.map((e) => e * 0.8),
       },
       bufferSize: TestData.VALID_SIGNAL.length,
     });
 
-    expect(en).toEqual(2.1288412531209104e-8);
+    expect(en).toEqual(0.5028486117726443);
 
     done();
   });

--- a/__tests__/extractors/spectralFlux.ts
+++ b/__tests__/extractors/spectralFlux.ts
@@ -12,11 +12,12 @@ describe("spectralFlux", () => {
       complexSpectrum: COMPLEX_SPECTRUM,
       previousComplexSpectrum: {
         real: COMPLEX_SPECTRUM.real.map((e) => e * 0.8),
+        imag: COMPLEX_SPECTRUM.real.map((e) => e * 0.8),
       },
       bufferSize: TestData.VALID_SIGNAL.length,
     });
 
-    expect(en).toEqual(1.03425562865083e-7);
+    expect(en).toEqual(0.9351257452798406);
 
     done();
   });

--- a/src/extractors/positiveFlux.ts
+++ b/src/extractors/positiveFlux.ts
@@ -1,4 +1,4 @@
-import { normalizeToOne } from "../utilities";
+import { magnitudeForComplexSpectrum, normalizeToOne } from "../utilities";
 
 export default function ({
   complexSpectrum,
@@ -11,16 +11,21 @@ export default function ({
     return 0;
   }
 
-  const normalizedRealComponent = normalizeToOne(complexSpectrum.real);
-  const previousNormalizedRealComponent = normalizeToOne(
-    previousComplexSpectrum.real
+  const magnitudeSpectrum = magnitudeForComplexSpectrum(complexSpectrum);
+  const previousMagnitudeSpectrum = magnitudeForComplexSpectrum(
+    previousComplexSpectrum
+  );
+
+  const normalizedMagnitudeSpectrum = normalizeToOne(magnitudeSpectrum);
+  const previousNormalizedMagnitudeSpectrum = normalizeToOne(
+    previousMagnitudeSpectrum
   );
 
   let sf = 0;
-  for (let i = 0; i < normalizedRealComponent.length; i++) {
+  for (let i = 0; i < normalizedMagnitudeSpectrum.length; i++) {
     let x =
-      Math.abs(previousNormalizedRealComponent[i]) -
-      Math.abs(normalizedRealComponent[i]);
+      Math.abs(normalizedMagnitudeSpectrum[i]) -
+      Math.abs(previousNormalizedMagnitudeSpectrum[i]);
     sf += Math.pow(Math.max(x, 0), 2);
   }
 

--- a/src/extractors/spectralFlux.ts
+++ b/src/extractors/spectralFlux.ts
@@ -1,4 +1,4 @@
-import { normalizeToOne } from "../utilities";
+import { magnitudeForComplexSpectrum, normalizeToOne } from "../utilities";
 
 export default function ({
   complexSpectrum,
@@ -11,16 +11,21 @@ export default function ({
     return 0;
   }
 
-  const normalizedRealComponent = normalizeToOne(complexSpectrum.real);
-  const previousNormalizedRealComponent = normalizeToOne(
-    previousComplexSpectrum.real
+  const magnitudeSpectrum = magnitudeForComplexSpectrum(complexSpectrum);
+  const previousMagnitudeSpectrum = magnitudeForComplexSpectrum(
+    previousComplexSpectrum
+  );
+
+  const normalizedMagnitudeSpectrum = normalizeToOne(magnitudeSpectrum);
+  const previousNormalizedMagnitudeSpectrum = normalizeToOne(
+    previousMagnitudeSpectrum
   );
 
   let sf = 0;
-  for (let i = 0; i < normalizedRealComponent.length; i++) {
+  for (let i = 0; i < normalizedMagnitudeSpectrum.length; i++) {
     let x =
-      Math.abs(normalizedRealComponent[i]) -
-      Math.abs(previousNormalizedRealComponent[i]);
+      Math.abs(normalizedMagnitudeSpectrum[i]) -
+      Math.abs(previousNormalizedMagnitudeSpectrum[i]);
     sf += Math.pow(x, 2);
   }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -272,3 +272,10 @@ export function frame(buffer, frameLength, hopLength) {
     .fill(0)
     .map((_, i) => buffer.slice(i * hopLength, i * hopLength + frameLength));
 }
+
+export function magnitudeForComplexSpectrum(complexSpectrum) {
+  return complexSpectrum.real.map((real, i) => {
+    const imag = complexSpectrum.imag[i];
+    return Math.sqrt(Math.pow(real, 2) + Math.pow(imag, 2));
+  });
+}


### PR DESCRIPTION
This runs spectral flux on the magnitude spectrum, both for `spectralFlux` and `positiveFlux`.

Of course, I'm an idiot and didn't remember that amp spectrum is the same as magnitude spectrum and wrote a new thing, rather than use our existing amp spectrum, so I'll fix that.

For positiveFlux, I think I've done something wrong. The following is a graph of spectral flux over the entire course of the elvis song on the meyda demo page. The big flux peak is at the end of the song, rather than the start. I guess maybe there's a click there and that could've been fine. I've checked the maths but like, who knows.

![image](https://user-images.githubusercontent.com/829836/141833378-684f3756-4132-4172-bd45-9056ade75980.png)

cc @nevosegal 

Also, should we provide a magnitudeSpectrum feature? 

re #1074