### PR TITLE
New-extract-tuple-lengths

### DIFF
--- a/src/new-extract/new-extract.test.ts
+++ b/src/new-extract/new-extract.test.ts
@@ -138,9 +138,8 @@ describe.skip("configureMeydaWithExtractors", () => {
 
     const myExtractor = configureMeydaWithExtractors(features);
 
-    // DELETE
-    // @ts-expect-error
     let r = myExtractor([DUMMY_SIGNAL, DUMMY_SIGNAL]);
+    expect(Array.isArray(r)).toBeTruthy();
     // @ts-expect-error
     r.rms;
   });
@@ -204,31 +203,22 @@ describe.skip("configureMeydaWithExtractors", () => {
   });
 });
 
-describe.skip("configureMeydaWithExtractors", () => {
-  test("is correct when the internal `curryMeyda` function wraps the extractor", () => {
-    const testFeatures: MeydaAudioFeature[] = [...features];
-    const extract = configureMeydaWithExtractors(testFeatures);
-    let r = extract(DUMMY_SIGNAL);
-    // @ts-expect-error
-    r.rms;
-  });
-  test("is correct when the internal `curryMeyda` function wraps the extractor", () => {
-    const extract = configureMeydaWithExtractors("zcr" as MeydaAudioFeature);
-    let r = extract(DUMMY_SIGNAL);
-    // @ts-expect-error
-    r.rms;
-  });
-  test("is correct when the internal `curryMeyda` function wraps the extractor", () => {
-    const extract = configureMeydaWithExtractors(features);
-    let r = extract([DUMMY_SIGNAL]);
-    // @ts-expect-error
-    r.rms;
-  });
-  test("is correct when the internal `curryMeyda` function wraps the extractor", () => {
-    const extract = configureMeydaWithExtractors("zcr");
-    let r = extract([DUMMY_SIGNAL]);
-    // @ts-expect-error
-    r.rms;
+describe.skip("When the features are not readonly", () => {
+  describe("the return type", () => {
+    test.skip("is correct when the internal `curryMeyda` function wraps the extractor", () => {
+      const testFeatures: MeydaAudioFeature[] = [...features];
+      const extract = configureMeydaWithExtractors(testFeatures);
+      let r = extract(DUMMY_SIGNAL);
+
+      // r should be Partial<ReturnTypesOf<ExtractorMap>>
+    });
+
+    test.skip("is correct when the internal `curryMeyda` function wraps the extractor", () => {
+      const extract = configureMeydaWithExtractors("zcr" as MeydaAudioFeature);
+      let r = extract(DUMMY_SIGNAL);
+
+      // r should be Partial<ReturnTypesOf<ExtractorMap>>
+    });
   });
 
   test("", () => {

--- a/src/new-extract/new-extract.ts
+++ b/src/new-extract/new-extract.ts
@@ -17,26 +17,12 @@ type ParameterTypesOf<T extends Record<string, (...args: any) => any>> = {
   [K in keyof T]: Parameters<T[K]>;
 };
 
-type RelevantExtractorParams<
-  M extends Record<string, (...args: any) => any>,
-  T extends keyof M
-> = {
-  [ExtractorName in T]: ParameterTypesOf<M>[ExtractorName];
-};
-
-type AllMeydaExtractorParams<T extends keyof ExtractorMap> =
-  RelevantExtractorParams<ExtractorMap, T>;
-
 type ReturnTypesOf<T extends Record<string, (...args: any) => any>> = {
   [K in keyof T]: ReturnType<T[K]>;
 };
 
-type MeydaExtractionResult<F extends MeydaAudioFeature> = {
-  [ExtractorName in F]: ReturnTypesOf<ExtractorMap>[ExtractorName];
-};
 type MelFilterBank = ReturnType<typeof createMelFilterBank>;
 type ChromaFilterBank = ReturnType<typeof createChromaFilterBank>;
-
 interface MeydaConfigurationOptions {
   sampleRate: number;
   bufferSize: number;
@@ -75,20 +61,14 @@ function configure(options: MeydaConfigurationOptions): MeydaConfiguration {
 type ConcreteResultType<
   T extends MeydaAudioFeature,
   U extends MeydaSignal[] | MeydaSignal
-> = U extends MeydaSignal[]
+> =
+ U extends MeydaSignal[]
   ? {
       [ExtractorName in T]: ReturnTypesOf<ExtractorMap>[ExtractorName];
     }[]
   : {
       [ExtractorName in T]: ReturnTypesOf<ExtractorMap>[ExtractorName];
     };
-
-/**
- * If T is an array, the result type is U[]. Otherwise, the result type is U.
- */
-type MatchArrayWrap<T, U, V> = T extends Array<V> ? U[] : U;
-
-type OnlyOne<T> = T extends Array<(infer U)[]> ? U : T;
 
 /**
  * # Configure an extractor


### PR DESCRIPTION
Refine the return type of new extract such that the result of an extraction is a tuple of MeydaResult with the same number of elements as the array passed in containing signals. This can only work for readonly signal arrays with less than 20 elements, otherwise it will fall back to using MeydaResult[].