### PR TITLE
feat: spectral crest extractor

### DIFF
--- a/__tests__/extractors/spectralCrest.ts
+++ b/__tests__/extractors/spectralCrest.ts
@@ -1,0 +1,40 @@
+import TestData from "../TestData";
+
+// Setup
+var spectralCrest = require("../../dist/node/extractors/spectralCrest");
+
+describe("spectralCrest", () => {
+  test("should return correct spectrla crest value", (done) => {
+    var en = spectralCrest({
+      ampSpectrum: TestData.VALID_AMPLITUDE_SPECTRUM,
+    });
+
+    expect(en).toEqual(10.35858484810692);
+
+    done();
+  });
+
+  test("should throw an error when passed an empty object", (done) => {
+    try {
+      var en = spectralCrest({});
+    } catch (e) {
+      done();
+    }
+  });
+
+  test("should throw an error when not passed anything", (done) => {
+    try {
+      var en = spectralCrest();
+    } catch (e) {
+      done();
+    }
+  });
+
+  test("should throw an error when passed something invalid", (done) => {
+    try {
+      var en = spectralCrest({ signal: "not a signal" });
+    } catch (e) {
+      done();
+    }
+  });
+});

--- a/docs/audio-features.md
+++ b/docs/audio-features.md
@@ -124,6 +124,14 @@ To use RMS in applications where you expect a ceiling on each audio feature, we 
 - _What Is It Used For_: Often used to indicate "pitchiness / tonality" of a sound.
 - _Range_: `0.0 - 1.0`, where `0.0` is not tonal, and `1.0` is very tonal.
 
+### Spectral Crest
+
+`spectralCrest`
+
+- _Description_: This is the ratio of the loudest magnitude over the RMS of the whole frame. A high number is an indication of a loud peak compared out to the overall curve of the spectrum.
+- _What Is It Used For_: If the spectrum you are analysing has peaks in it, it can help discern _how peaky_ it is.
+- _Range_: The range is arbitrary, with higher values indicating more extreme peaks in the spectrum.
+
 ### Chroma
 
 `chroma`

--- a/src/extractors/spectralCrest.ts
+++ b/src/extractors/spectralCrest.ts
@@ -1,0 +1,22 @@
+export default function ({
+  ampSpectrum,
+}: {
+  ampSpectrum: Float32Array;
+}): number {
+  if (typeof ampSpectrum !== "object") {
+    throw new TypeError();
+  }
+
+  var rms = 0;
+  var peak = -Infinity;
+
+  ampSpectrum.forEach((x) => {
+    rms += Math.pow(x, 2);
+    peak = x > peak ? x : peak;
+  });
+
+  rms = rms / ampSpectrum.length;
+  rms = Math.sqrt(rms);
+
+  return peak / rms;
+}

--- a/src/featureExtractors.ts
+++ b/src/featureExtractors.ts
@@ -15,6 +15,7 @@ import mfcc from "./extractors/mfcc";
 import chroma from "./extractors/chroma";
 import powerSpectrum from "./extractors/powerSpectrum";
 import spectralFlux from "./extractors/spectralFlux";
+import spectralCrest from "./extractors/spectralCrest";
 
 let buffer = function (args) {
   return args.signal;
@@ -49,4 +50,5 @@ export {
   mfcc,
   chroma,
   spectralFlux,
+  spectralCrest,
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ export interface MeydaFeaturesObject {
   spectralSkewness: number;
   spectralSlope: number;
   spectralSpread: number;
+  spectralCrest: number;
   zcr: number;
 }
 
@@ -62,6 +63,7 @@ export type MeydaAudioFeature =
   | "spectralSkewness"
   | "spectralSlope"
   | "spectralSpread"
+  | "spectralCrest"
   | "zcr"
   | "buffer";
 


### PR DESCRIPTION
This adds a new extractor for computing the [crest](https://www.mathworks.com/help/audio/ug/spectral-descriptors.html#SpectralDescriptorsExample-7) of the amplitude spectrum. In theory, the descriptor will indicate if there is a peaky bin compared to the overall spectral curve.

Tests pass, and using the provided valid ampSpectrum frame I derived the value that should be returned by first checking in Max with [FrameLib](https://github.com/AlexHarker/FrameLib) as well as in Python.

In terms of style I opted for something quite terse and leveraged `.forEach()`. I hope this is okay.