### PR TITLE
fix(engines): remove package.json engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,9 +70,6 @@
     "node-getopt": "^0.3.2",
     "wav": "^1.0.2"
   },
-  "engines": {
-    "node": "^10 || ^12 || ^13 || ^14 || ^15 || ^16 || ^17 || ^18 || ^19"
-  },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",


### PR DESCRIPTION
I'm proposing that we remove the "engines" field from package.json. We
first introduced this in response to a version of node being released
where the v8 dep had increased precision on floating point calculations,
throwing off feature extractors. We wanted to be able to catch when this
happened, and therefore be able to write in release notes when we add
support for new versions that users should pay attention to that.

That never happened again. And besides, that's something we can catch
simply by running our test suite on all current node versions (which
we will continue to do).

We have had a lot of friction when new node versions are released. Users
see the warning generated by npm on the `engines` compatibility and
sometimes they open a PR (or just an issue). Then I don't see it soon
enough (my GitHub notifications are untenable), and that's not great.
Better to just be rid of it.

I don't consider this to be a breaking change really, but I'm open to
being corrected!

Hope everyone reading this is having a wonderful 2023!